### PR TITLE
adding support for library(here)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,8 @@ Depends:
     R (>= 3.4.0)
 Imports:
     magick,
-    usethis
+    usethis,
+    here
 Suggests:
     tidyverse,
     urbnthemes,

--- a/inst/templates/fact_sheet_html.Rmd
+++ b/inst/templates/fact_sheet_html.Rmd
@@ -2,7 +2,7 @@
 title: ""
 author: ""
 date: "`r format(Sys.time(), '%d %B, %Y')`"
-css: www/web_report.css
+css: !expr here::here("www", "web_report.css")
 output:
   html_document:
   code_folding: hide

--- a/inst/templates/revealjs.Rmd
+++ b/inst/templates/revealjs.Rmd
@@ -1,7 +1,7 @@
 ---
 output:
   revealjs::revealjs_presentation:
-    css: www/revealjs.css
+    css: !expr here::here("www", "revealjs.css")
     incremental: TRUE
     reveal_options:
       slideNumber: TRUE

--- a/inst/templates/web_report.Rmd
+++ b/inst/templates/web_report.Rmd
@@ -9,7 +9,7 @@ output:
     code_folding: hide
     toc: TRUE
     toc_float: TRUE
-    css: www/web_report.css
+    css: !expr here::here("www", "web_report.css")
     editor_options:
       chunk_output_type: console
 ---


### PR DESCRIPTION
Hello @awunderground! The purpose of this pull request is to use `library(here)` in the R Markdown templates, so that they can be moved into sub-directories without editing the file path to the CSS each time.

I don't know how to handle the PDF template, since the file paths are written differently?

I added `here` to imports, since it it referenced with `::` and does not need to be loaded